### PR TITLE
Fix bug for saving empty username/email in user settings

### DIFF
--- a/frontend/components/user-settings/user-settings.tsx
+++ b/frontend/components/user-settings/user-settings.tsx
@@ -134,6 +134,14 @@ export default function UserSettings({ userId }: { userId: string }) {
         return;
       }
 
+      if (!user.username || !user.email) {
+        toast({
+          title: "Changes denied ❌",
+          description: "Username or/and Email fields cannot be empty!",
+        });
+        return;
+      }
+
       try {
         const response = await fetch(`http://localhost:3001/users/${userId}`, {
           method: "PATCH",


### PR DESCRIPTION
Resolves #109.

## Changes
- Extra check for the existence of username/email string in the `handleSaveChanges` function (Error toast message displayed if empty username/email strings are submitted)
![image](https://github.com/user-attachments/assets/05ca7935-2829-4415-bbad-0c6968f991c2)
