### PR TITLE
Add CORS middleware for question-service

### DIFF
--- a/question-service/app/main.py
+++ b/question-service/app/main.py
@@ -1,8 +1,21 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from app.routers import questions
 
 app = FastAPI(title="Question Service API")
+
+origins = [
+    "http://localhost:3000",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # Include routers
 app.include_router(questions.router, prefix="/questions", tags=["questions"])


### PR DESCRIPTION
## Overview
Currently, there is no CORS policy for `question-service`, any requests made by the frontend will not be permitted.

## Changelog
* Add FastAPI CORS middleware