### PR TITLE
Add workaround for MongoDB id

### DIFF
--- a/question-service/app/crud/questions.py
+++ b/question-service/app/crud/questions.py
@@ -1,4 +1,4 @@
-from app.models.questions import QuestionModel
+from app.models.questions import QuestionCollection, QuestionModel
 from dotenv import load_dotenv
 import motor.motor_asyncio
 import os
@@ -20,6 +20,6 @@ async def create_question(question: QuestionModel):
     new_question = await question_collection.insert_one(question.model_dump())
     return await question_collection.find_one({"_id": new_question.inserted_id})
 
-async def get_all_questions():
+async def get_all_questions() -> QuestionCollection:
     questions = await question_collection.find().to_list(1000)
-    return {"questions": questions}
+    return QuestionCollection(questions=questions)

--- a/question-service/app/models/object_id.py
+++ b/question-service/app/models/object_id.py
@@ -1,0 +1,11 @@
+from pydantic import BeforeValidator
+from typing import Annotated
+
+'''
+Pydantic does not directly support mapping of MongoDB's id fields. Workaround is used as such to allow for
+mapping of this field.
+
+Source:
+https://www.mongodb.com/developer/languages/python/python-quickstart-fastapi/#the-_id-attribute-and-objectids
+'''
+PyObjectId = Annotated[str, BeforeValidator(str)]

--- a/question-service/app/models/questions.py
+++ b/question-service/app/models/questions.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from pydantic import BaseModel, ConfigDict, Field
-from typing import Optional
+from typing import List, Optional
 
 from .object_id import PyObjectId
 
@@ -22,4 +22,4 @@ class QuestionModel(BaseModel):
     complexity: ComplexityEnum
 
 class QuestionCollection(BaseModel):
-    questions: list[QuestionModel]
+    questions: List[QuestionModel]

--- a/question-service/app/models/questions.py
+++ b/question-service/app/models/questions.py
@@ -1,5 +1,8 @@
 from enum import Enum
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
+from typing import Optional
+
+from .object_id import PyObjectId
 
 class ComplexityEnum(str, Enum):
     easy = "easy"
@@ -7,6 +10,12 @@ class ComplexityEnum(str, Enum):
     hard = "hard"
 
 class QuestionModel(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+    )
+
+    id: Optional[PyObjectId] = Field(validation_alias="_id", default=None)
     title: str
     description: str
     category: str

--- a/question-service/app/routers/questions.py
+++ b/question-service/app/routers/questions.py
@@ -2,12 +2,9 @@ from fastapi import APIRouter, HTTPException
 from app.models.questions import QuestionModel, QuestionCollection
 from app.crud.questions import create_question, get_all_questions
 
-router = APIRouter(
-    prefix="/questions",
-    tags=["questions"]
-)
+router = APIRouter()
 
-@router.post("/questions/",
+@router.post("/",
             response_description="Create new question",
             response_model=QuestionModel,
             responses={


### PR DESCRIPTION
## Overview
Pydantic does not directly support ORM for MongoDB id. Used workaround found in the [MongoDB dev page for python](https://www.mongodb.com/developer/languages/python/python-quickstart-fastapi/#the-_id-attribute-and-objectids).

## Changelog
* Added `object_id.py`
* Changed the following routes
    * `create` from `/question/questions/questions` to `/questions`
    * `get_all` from `/question/questions` to `/questions`
