### PR TITLE
Add CreateQuestionModel to question-service

### DIFF
--- a/question-service/app/crud/questions.py
+++ b/question-service/app/crud/questions.py
@@ -1,4 +1,4 @@
-from app.models.questions import QuestionCollection, QuestionModel
+from app.models.questions import CreateQuestionModel, QuestionCollection, QuestionModel
 from dotenv import load_dotenv
 import motor.motor_asyncio
 import os
@@ -13,7 +13,7 @@ client = motor.motor_asyncio.AsyncIOMotorClient(DB_CLOUD_URI)
 db = client.get_database("question_service")
 question_collection = db.get_collection("questions")
 
-async def create_question(question: QuestionModel):
+async def create_question(question: CreateQuestionModel):
     existing_question = await question_collection.find_one({"title": question.title})
     if existing_question:
         return None

--- a/question-service/app/models/questions.py
+++ b/question-service/app/models/questions.py
@@ -23,3 +23,9 @@ class QuestionModel(BaseModel):
 
 class QuestionCollection(BaseModel):
     questions: List[QuestionModel]
+
+class CreateQuestionModel(BaseModel):
+    title: str
+    description: str
+    category: str
+    complexity: ComplexityEnum

--- a/question-service/app/routers/questions.py
+++ b/question-service/app/routers/questions.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException
-from app.models.questions import QuestionModel, QuestionCollection
+from app.models.questions import CreateQuestionModel, QuestionModel, QuestionCollection
 from app.crud.questions import create_question, get_all_questions
 
 router = APIRouter()
@@ -19,7 +19,7 @@ router = APIRouter()
                 }
                 ,
             })
-async def create(question: QuestionModel):
+async def create(question: CreateQuestionModel):
     existing_question = await create_question(question)
     if existing_question is None:
         raise HTTPException(status_code=409, detail="Question with this title already exists.")


### PR DESCRIPTION
## Overview
As `QuestionModel` is different from the required model for the creation of question, we add `CreateQuestionModel` to account for this difference. This prevents the user from specifying the question id.