### PR TITLE
Fix bug where toast message does not appear for wrong login credentials

### DIFF
--- a/frontend/components/auth/login-form.tsx
+++ b/frontend/components/auth/login-form.tsx
@@ -28,13 +28,17 @@ export function LoginForm() {
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    const user = await auth?.login(email, password);
-    if (user?.isAdmin) {
-      router.push("/app/admin-user-management");
-    } else if (user) {
-      router.push("/app/questions");
-    } else {
-      toast({ title: "Error", description: "Login Failed." });
+    try {
+      const user = await auth?.login(email, password);
+      if (user?.isAdmin) {
+        router.push("/app/admin-user-management");
+      } else if (user) {
+        router.push("/app/questions");
+      } else {
+        toast({ title: "Error", description: "Login Failed." });
+      }
+    } catch (err) {
+      toast({ title: "Error", variant: "destructive", description: "Login Failed." });
     }
   };
 

--- a/frontend/components/auth/login-form.tsx
+++ b/frontend/components/auth/login-form.tsx
@@ -15,7 +15,7 @@ import { Label } from "@/components/ui/label";
 import { useState } from "react";
 import { useAuth } from "@/app/auth/auth-context";
 import { useRouter } from "next/navigation";
-import { useToast } from "../hooks/use-toast";
+import { useToast } from "@/components/hooks/use-toast";
 import { EyeIcon, EyeOffIcon } from "lucide-react";
 
 export function LoginForm() {

--- a/frontend/components/auth/login-form.tsx
+++ b/frontend/components/auth/login-form.tsx
@@ -35,7 +35,7 @@ export function LoginForm() {
       } else if (user) {
         router.push("/app/questions");
       } else {
-        toast({ title: "Error", description: "Login Failed." });
+        toast({ title: "Error", variant: "destructive", description: "Login Failed." });
       }
     } catch (err) {
       toast({ title: "Error", variant: "destructive", description: "Login Failed." });


### PR DESCRIPTION
Resolves #131. 

## Changes made
- Add `try catch` statement block within `handleSubmit` function of `login-form.tsx` component. Toast with error message will be shown when error from `AuthContext`'s login function is caught.