### PR TITLE
Fix duplicate handling in update questions backend

### DIFF
--- a/question-service/app/crud/questions.py
+++ b/question-service/app/crud/questions.py
@@ -39,7 +39,11 @@ async def delete_question(question_id: str):
 async def update_question_by_id(question_id: str, question_data: UpdateQuestionModel):
     existing_question = await question_collection.find_one({"_id": ObjectId(question_id)})
     if existing_question is None:
-        return None
+        return {"error": "does not exist"}
+    
+    duplicate_question = await question_collection.find_one({"title": question_data.title})
+    if duplicate_question:
+        return {"error": "duplicate"}
     
     updated_data = {"$set": question_data.model_dump(exclude_unset=True)}
     if not updated_data["$set"]:

--- a/question-service/app/routers/questions.py
+++ b/question-service/app/routers/questions.py
@@ -46,7 +46,11 @@ async def delete(question_id: str):
 @router.put("/{question_id}", response_description="Update question with specified id", response_model=QuestionModel)
 async def update_question(question_id: str, question_data: UpdateQuestionModel):
     updated_question = await update_question_by_id(question_id, question_data)
-    if updated_question is None:
-        raise HTTPException(status_code=404, detail="Question with this id does not exist.")
+    
+    if "error" in updated_question:
+        if updated_question["error"] == "does not exist":
+            raise HTTPException(status_code=404, detail="Question with this id does not exist.")
+        if updated_question["error"] == "duplicate":
+            raise HTTPException(status_code=409, detail="Question with this title already exists.")
     
     return updated_question


### PR DESCRIPTION
Previously, the update question endpoint failed to check for duplicate title in the database, allowing for duplicates titles to be stored in the database.

## Changes made
- Add in check for duplicate questions, return 409 if there are duplicates