### PR TITLE
Remove semicolon in user settings page

### DIFF
--- a/frontend/app/app/user-settings/[user_id]/page.tsx
+++ b/frontend/app/app/user-settings/[user_id]/page.tsx
@@ -8,7 +8,7 @@ export default function UserSettingsPage({
 }) {
   return (
     <AuthPageWrapper requireLoggedIn userId={params.user_id}>
-      <UserSettings userId={params.user_id} />;
+      <UserSettings userId={params.user_id} />
     </AuthPageWrapper>
   );
 }


### PR DESCRIPTION
There used to be an extra semicolon showing up in user settings 
<img width="437" alt="image" src="https://github.com/user-attachments/assets/35a4596c-4d2d-4ade-b460-e5443bdb42b3">
<img width="687" alt="image" src="https://github.com/user-attachments/assets/7923b524-44db-4af0-b896-56232f652305">

