### PR TITLE
Matching Service: Fix missing toast for 1st matched user

### DIFF
--- a/frontend/components/matching/find-match.tsx
+++ b/frontend/components/matching/find-match.tsx
@@ -135,6 +135,11 @@ export default function FindMatch() {
               isMatched = true;
               setIsSearching(false);
               clearTimeout(queueTimeout);
+              toast({
+                title: "Matched",
+                description: "Successfully matched",
+                variant: "success",
+              });
               router.push(`/app/collab/${room_id}`);
             }
           } catch (error) {


### PR DESCRIPTION

https://github.com/user-attachments/assets/5eff91a7-08b2-410a-ba31-7cb29ec595e8

As shown in the screen recording, amongst the two matched users, the match success toast does not show up for the 1st user (aka the user waiting in the queue). This PR will fix this bug and ensures that the match success toast appears for both users upon successful matching.

Note: Commit message should be "1st matched user" but no biggie.